### PR TITLE
Running installation from fat32 and displaying info

### DIFF
--- a/linux-live/bootfiles/boot/bootinst.sh
+++ b/linux-live/bootfiles/boot/bootinst.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Setup booting from disk (USB or harddrive)
 # Requires: fdisk, df, tail, tr, cut, dd, sed
+# If this script is placed on a fat32 (vfat) partition, 
+#                   run it with `sudo bash bootinst.sh`
 
 # change working directory to dir from which we are started
 CWD="$(pwd)"
@@ -12,10 +14,34 @@ PART="$(df . | tail -n 1 | tr -s " " | cut -d " " -f 1)"
 DEV="$(echo "$PART" | sed -r "s:[0-9]+\$::" | sed -r "s:([0-9])[a-z]+\$:\\1:i")"   #"
 
 ARCH=$(uname -m)
-if [ "$ARCH" = "x86_64" ]; then ARCH=64; else ARCH=32; fi
-EXTLINUX=extlinux.x$ARCH
 
-./"$EXTLINUX" --install "$BOOT"
+if ! [ -w "$DEV" ]; then
+    echo "You have no permissions to write to ${DEV}."
+    echo "You should run this script with sudo."
+    exit 1
+fi
+
+echo "MiniOS will be installed to:"
+
+echo "    Target device:   " $DEV
+echo "    Target partition:" $PART
+echo "    CPU architecture:" $ARCH
+
+echo "If this is what you want, press ENTER to continue."
+echo "If this is incorrect, press Ctrl+C to abort."
+read r
+
+echo "Beginning installation..."
+
+if [ "$ARCH" = "x86_64" ]; then 
+    ARCH=64; 
+    EXTLINUX=extlinux.x$ARCH
+    /lib64/ld-linux-x86-64.so.2 ./"$EXTLINUX" --install "$BOOT"
+else 
+    ARCH=32; 
+    EXTLINUX=extlinux.x$ARCH
+    /lib/ld-linux.so.2 ./"$EXTLINUX" --install "$BOOT"
+fi
 
 if [ $? -ne 0 ]; then
    echo "Error installing boot loader."


### PR DESCRIPTION
(1) On fat32 system, there are no executable flags for files, and so "./somefile" (as in line 18) invocation in the script won't work. So in order to execute the bash script from such a filesystem, we need to explicitly run it with bash, and then make it use ld-linux to run executable files that are on the very same filesystem. Instead of testing if ld-linux is actually needed, we can just use it all the time, since if the script is on a proper filesystem with normal permissions, it will work just the same anyway.

(2) The script now reports what it is going to do first, and then waits for confirmation. So if something isn't right, the user can always cancel the procedure.

(3) The script prints a warning and exits if it's not run with super-user privileges, since it won't be able to install anything anyway.