### PR TITLE
add file, xmlstarlet.

### DIFF
--- a/linux-live/prerequisites.list
+++ b/linux-live/prerequisites.list
@@ -11,3 +11,5 @@ mtools
 rsync
 grub-common
 gpg
+file
+xmlstarlet


### PR DESCRIPTION
On some distributions or container images, these packages are not installed by default.